### PR TITLE
Create dual navbar on farm detail

### DIFF
--- a/app/routes/FarmDetail/FarmDetail.js
+++ b/app/routes/FarmDetail/FarmDetail.js
@@ -1,66 +1,83 @@
 import React from 'react';
-import {Image, Text, TouchableOpacity, View} from 'react-native';
+import {Image, ScrollView, Text, TouchableOpacity, View} from 'react-native';
+import ScrollableTabView, {DefaultTabBar} from 'react-native-scrollable-tab-view';
 
-import styles from './styles'
+import styles from './styles';
+
+import EventsListContainer from '../EventsList';
 
 const FarmDetail = (props) => {
 	return (
 		<View style={styles.mainContainer}>
-			<View style={styles.logoContainer}>
-				<Image
-					source={require('../../images/farm.png')}
-					style={styles.logo}
-					/>
-			</View>
+			<ScrollView>
+				<View style={styles.informationContainer}>
+					<View style={styles.logoContainer}>
+						<Image
+							source={require('../../images/farm.png')}
+							style={styles.logo}
+							/>
+					</View>
 
-			<Text style={styles.name}>
-				{props.name}
-			</Text>
+					<Text style={styles.name}>
+						{props.name}
+					</Text>
 
-			<View style={styles.subtitleContainer}>
-				<View style={styles.iconContainer}>
-					<Image
-						source={require('../../images/farm.png')}
-						style={styles.icon}
-						/>
+					<View style={styles.subtitleContainer}>
+						<View style={styles.iconContainer}>
+							<Image
+								source={require('../../images/farm.png')}
+								style={styles.icon}
+								/>
+						</View>
+						<Text style={styles.subtitle}>
+							{props.address}
+						</Text>
+					</View>
+
+					<View style={styles.subtitleContainer}>
+						<View style={styles.iconContainer}>
+							<Image
+								source={require('../../images/phone.png')}
+								style={styles.icon}
+								/>
+						</View>
+						<Text style={styles.subtitle}>
+							{props.phone}
+						</Text>
+					</View>
+
+					<View style={styles.subtitleContainer}>
+						<View style={styles.iconContainer}>
+							<Image
+								source={require('../../images/farm.png')}
+								style={styles.icon}
+								/>
+						</View>
+						<Text style={styles.subtitle}>
+							{props.website}
+						</Text>
+					</View>
+
+					<TouchableOpacity
+						onPress={props.toggleSubscriptionStatus}
+						style={styles.buttonWrapper}
+						>
+						<Text style={styles.buttonText}>
+							{props.isSubscribed ? 'Me désabonner' : 'M\'abonner'}
+						</Text>
+					</TouchableOpacity>
 				</View>
-				<Text style={styles.subtitle}>
-					{props.address}
-				</Text>
-			</View>
 
-			<View style={styles.subtitleContainer}>
-				<View style={styles.iconContainer}>
-					<Image
-						source={require('../../images/phone.png')}
-						style={styles.icon}
-						/>
-				</View>
-				<Text style={styles.subtitle}>
-					{props.phone}
-				</Text>
-			</View>
+				<ScrollableTabView renderTabBar={() => <DefaultTabBar />}>
+					<View tabLabel='Évènements'>
+						<EventsListContainer/>
+					</View>
+					<ScrollView tabLabel='Produits'>
+						<Text>Voici mes produits</Text>
+					</ScrollView>
+				</ScrollableTabView>
 
-			<View style={styles.subtitleContainer}>
-				<View style={styles.iconContainer}>
-					<Image
-						source={require('../../images/farm.png')}
-						style={styles.icon}
-						/>
-				</View>
-				<Text style={styles.subtitle}>
-					{props.website}
-				</Text>
-			</View>
-
-			<TouchableOpacity
-				onPress={props.toggleSubscriptionStatus}
-				style={styles.buttonWrapper}
-				>
-				<Text style={styles.buttonText}>
-					{props.isSubscribed ? 'Me désabonner' : 'M\'abonner'}
-				</Text>
-			</TouchableOpacity>
+			</ScrollView>
 		</View>
 	)
 }

--- a/app/routes/FarmDetail/styles.js
+++ b/app/routes/FarmDetail/styles.js
@@ -23,6 +23,9 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		flex: 0.2
 	},
+	informationContainer: {
+		alignItems: 'center',
+	},
 	logo: {
 		borderRadius: 50,
 		height: 100,
@@ -34,7 +37,6 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 	},
 	mainContainer: {
-		alignItems: 'center',
 		flex: 1,
 		top: metrics.navBarHeight,
 	},

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "react": "15.4.1",
     "react-native": "0.38.1",
-    "react-native-router-flux": "^3.37.0"
+    "react-native-router-flux": "^3.37.0",
+    "react-native-scrollable-tab-view": "^0.7.1"
   },
   "jest": {
     "preset": "react-native"


### PR DESCRIPTION
- import new dependency `react-native-scrollable-tab-view` (https://github.com/skv-headless/react-native-scrollable-tab-view)
- Create new dual tab for events and products (still not in place because the component doesn't exist)
- For the moment there is a problem, because the the new nav-bar doesn't anchor at the top of the page


![gravacao de tela 1](https://cloud.githubusercontent.com/assets/12020091/22040656/e5bfb216-dd03-11e6-897f-4d02ed28ad1d.gif)
