### PR TITLE
Persist redux store on async storage

### DIFF
--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -1,11 +1,36 @@
 import { applyMiddleware, createStore } from 'redux'
 import logger from 'redux-logger'
+import * as storage from 'redux-storage';
+import createEngine from 'redux-storage-engine-reactnativeasyncstorage';
 import thunkMiddleware from 'redux-thunk'
 
 import rootReducer from './reducers'
 
-const middleware = applyMiddleware(logger(), thunkMiddleware)
+const middleWare = [];
+
+// Add thunk middleWare
+middleWare.push(thunkMiddleware);
+
+// Add redux store storage reducer
+const wrappedReducer = storage.reducer(rootReducer);
+let engine = createEngine('radiSaclay');
+// TODO: debounce
+// TODO: filter
+const reduxStorageMiddleware = storage.createMiddleware(engine);
+middleWare.push(reduxStorageMiddleware);
+const loadStore = storage.createLoader(engine);
+
+
+// Add logger middleWare. This has always to be the last
+middleWare.push(logger())
+
+
+const createStoreWithMiddleware = applyMiddleware(...middleWare)(createStore);
 
 export default function configureStore() {
-	return createStore(rootReducer, middleware)
+	const store = createStoreWithMiddleware(wrappedReducer);
+	loadStore(store)
+	.then((newState) => {})
+	.catch((error) => { console.log('Failed to load previous store'); })
+	return store;
 }

--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -1,6 +1,7 @@
 import { applyMiddleware, createStore } from 'redux'
 import logger from 'redux-logger'
 import * as storage from 'redux-storage';
+import debounce from 'redux-storage-decorator-debounce';
 import createEngine from 'redux-storage-engine-reactnativeasyncstorage';
 import thunkMiddleware from 'redux-thunk'
 
@@ -14,8 +15,9 @@ middleWare.push(thunkMiddleware);
 // Add redux store storage reducer
 const wrappedReducer = storage.reducer(rootReducer);
 let engine = createEngine('radiSaclay');
-// TODO: debounce
-// TODO: filter
+// Throttle save operation to every once a second at max
+engine = debounce(engine, 1000);
+// TODO: parameter filter to save only parts of the store
 const reduxStorageMiddleware = storage.createMiddleware(engine);
 middleWare.push(reduxStorageMiddleware);
 const loadStore = storage.createLoader(engine);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.7.4",
     "redux-mock-store": "^1.2.1",
+    "redux-storage": "^4.1.2",
+    "redux-storage-engine-reactnativeasyncstorage": "^1.0.5",
     "redux-thunk": "^2.2.0"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "redux-logger": "^2.7.4",
     "redux-mock-store": "^1.2.1",
     "redux-storage": "^4.1.2",
+    "redux-storage-decorator-debounce": "^1.1.3",
     "redux-storage-engine-reactnativeasyncstorage": "^1.0.5",
     "redux-thunk": "^2.2.0"
   },


### PR DESCRIPTION
## PR goals ##
- persist the whole store on the `AsyncStorage`
- throttle saving operation to every once a second at most, because it's a costly operation. Otherwise it would be fired at every redux action

Reference: [Setting up your Redux Store](https://medium.com/@spencer_carli/setting-up-your-redux-store-3016eff82d83#.rkuh9i1o2)

## Bonus ##
- warnings on events, farms and products list was eliminated
- once the app is reloaded, the get requests succeed because the `idToken` is recovered from the persisted store

## Notes ##
For now the whole store is being saved in the `AsyncStorage`. It's possible to save only parts of the store with the package `'redux-storage-decorator-filter'`