### PR TITLE
Refactor header component

### DIFF
--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -1,14 +1,29 @@
 import React, { Component } from 'react'
 import { Text, View } from 'react-native'
+import Drawer from 'react-native-drawer'
 
 import styles from './styles'
 
 import ImageButton from '../ImageButton'
+import SideMenu from '../SideMenu'
 
 class Header extends Component {
+	openControlPanel() {
+		this._sideMenu.open()
+	}
+
 	render() {
 		return (
-			<View style={styles.mainContainer}>
+			<Drawer
+				acceptPan={true}
+				content={<SideMenu actions={this.props.menuActions} />}
+				openDrawerOffset={0.1}
+				ref={(ref) => this._sideMenu = ref}
+				side="right"
+				tapToClose={true}
+				type="overlay"
+				>
+
 				<View style={styles.headerContainer}>
 					<View style={styles.navContainer}>
 						{
@@ -26,11 +41,11 @@ class Header extends Component {
 						</Text>
 					</View>
 
-					<View style={styles.actionsContainer}>
+					<View style={styles.quickActionsContainer}>
 						{
-							this.props.actions &&
-							this.props.actions.length > 0 &&
-							this.props.actions.map(function(action, key){
+							this.props.quickActions &&
+							this.props.quickActions.length > 0 &&
+							this.props.quickActions.map(function(action, key){
 								return (
 									<ImageButton
 										key={key}
@@ -40,24 +55,42 @@ class Header extends Component {
 								)
 							})
 						}
+
+						{
+							this.props.menuActions &&
+							this.props.menuActions.length > 0 &&
+							<ImageButton
+								onPress={this.openControlPanel.bind(this)}
+								source={require('../../images/menu.png')}
+								/>
+						}
 					</View>
 				</View>
-			</View>
+
+				<View style={styles.mainContainer}>
+					{this.props.children}
+				</View>
+			</Drawer>
 		)
 	}
 }
 
 Header.propTypes = {
 	// from parent
-	actions: React.PropTypes.arrayOf(
+	menuActions: React.PropTypes.arrayOf(
 		React.PropTypes.shape({
+			label: React.PropTypes.string.isRequired,
 			onPress: React.PropTypes.func.isRequired,
-			source: React.PropTypes.number.isRequired,
 	})),
 	navigation: React.PropTypes.shape({
 		onPress: React.PropTypes.func.isRequired,
 		source: React.PropTypes.number.isRequired,
 	}),
+	quickActions: React.PropTypes.arrayOf(
+		React.PropTypes.shape({
+			onPress: React.PropTypes.func.isRequired,
+			source: React.PropTypes.number.isRequired,
+	})),
 	title: React.PropTypes.string.isRequired,
 }
 

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -1,8 +1,12 @@
 import React, { Component } from 'react'
 import { Text, View } from 'react-native'
 import Drawer from 'react-native-drawer'
+import { ActionConst, Actions } from 'react-native-router-flux'
+import { connect } from 'react-redux'
 
 import styles from './styles'
+
+import * as userOperations from '../../operations/userOperations'
 
 import ImageButton from '../ImageButton'
 import SideMenu from '../SideMenu'
@@ -57,8 +61,6 @@ class Header extends Component {
 						}
 
 						{
-							this.props.menuActions &&
-							this.props.menuActions.length > 0 &&
 							<ImageButton
 								onPress={this.openControlPanel.bind(this)}
 								source={require('../../images/menu.png')}
@@ -92,6 +94,31 @@ Header.propTypes = {
 			source: React.PropTypes.number.isRequired,
 	})),
 	title: React.PropTypes.string.isRequired,
+
+	// from redux
+	userLogout: React.PropTypes.func,
 }
 
-export default Header
+const mapStateToProps = (store) => { return {} }
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		userLogout: () => dispatch(userOperations.userLogout())
+	}
+}
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+	stateProps.menuActions = ownProps.menuActions.concat([
+		{
+			// Adds logout option to the SideMenu
+			label: 'Logout',
+			onPress: function(){
+				dispatchProps.userLogout()
+				Actions.Authentication({type: ActionConst.REPLACE})
+			}
+		}
+	])
+	return Object.assign({}, ownProps, stateProps, dispatchProps)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Header);

--- a/app/components/Header/styles.js
+++ b/app/components/Header/styles.js
@@ -3,11 +3,6 @@ import colors from '../../config/colors';
 import metrics from '../../config/metrics';
 
 export default styles = StyleSheet.create({
-	actionsContainer: {
-		flex: 0.25,
-		flexDirection: 'row',
-		justifyContent: 'flex-end',
-	},
 	headerContainer: {
 		alignItems: 'center',
 		backgroundColor: colors.white,
@@ -19,16 +14,20 @@ export default styles = StyleSheet.create({
 		paddingRight: metrics.basePadding,
 	},
 	mainContainer: {
-		height: metrics.navBarHeight,
-		width: metrics.screenWidth,
+		flex: 1,
 	},
 	navContainer: {
 		flex: 0.25,
 		flexDirection: 'row',
 	},
+	quickActionsContainer: {
+		flex: 0.25,
+		flexDirection: 'row',
+		justifyContent: 'flex-end',
+	},
 	title: {
+		color: colors.black,
 		fontSize: 20,
-		fontWeight: 'bold',
 		textAlign: 'center',
 	},
 	titleContainer: {

--- a/app/config/colors.js
+++ b/app/config/colors.js
@@ -1,4 +1,5 @@
 const colors = {
+	black: 'black',
 	coral: '#ED6856',
 	greyLight: '#666666',
 	salmonLight: '#FAD6D1',

--- a/app/routes/AccountDisplay/AccountDisplay.js
+++ b/app/routes/AccountDisplay/AccountDisplay.js
@@ -1,75 +1,35 @@
 import React, { Component } from 'react';
-import {
-	Alert,
-	Image,
-	Text,
-	TextInput,
-	TouchableOpacity,
-	View
-} from 'react-native';
-import Drawer from 'react-native-drawer'
-import {
-	ActionConst,
-	Actions
-} from 'react-native-router-flux';
+import { Alert, Image, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
 
 import settings from '../../config/settings';
 import styles from './styles';
 
-import * as userOperations from '../../operations/userOperations'
-
 import Header from '../../components/Header'
-import SideMenu from '../../components/SideMenu'
 
 class AccountDisplay extends Component {
-	constructor() {
-		super()
-		this.actions = [
-			{
-				label: "Log out",
-				onPress: this.userLogout.bind(this),
-			},
-		]
-	}
-
-	userLogout() {
-		this.props.userLogout()
-		Actions.Authentication({type: ActionConst.REPLACE})
-	}
-
-	openControlPanel() {
-		this._sideMenu.open()
-	}
-
 	render() {
 		return (
-			<Drawer
-				acceptPan={true}
-				content={<SideMenu actions={this.actions} />}
-				openDrawerOffset={0.2}
-				ref={(ref) => this._sideMenu = ref}
-				side="right"
-				tapToClose={true}
-				type="overlay"
+			<Header
+				menuActions={[
+					{
+						label: 'Awesome option',
+						onPress: function(){Alert.alert('Incredible option')},
+					}
+				]}
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.News()},
+				}}
+				quickActions={[
+					{
+						source: require('../../images/settings.png'),
+						onPress: function(){Alert.alert('Settings Clicked !')},
+					}
+				]}
+				title={this.props.title}
 				>
-				<Header
-					actions={[
-						{
-							source: require('../../images/settings.png'),
-							onPress: function(){Alert.alert('Settings Clicked !')},
-						},
-						{
-							source: require('../../images/menu.png'),
-							onPress: this.openControlPanel.bind(this),
-						}
-					]}
-					navigation={{
-						source: require('../../images/back.png'),
-						onPress: function(){Actions.News()},
-					}}
-					title='Mon Compte'
-					/>
 
 				<View style={styles.mainContainer}>
 					{/* Firstname, lastname */}
@@ -139,21 +99,9 @@ class AccountDisplay extends Component {
 						</Text>
 					</TouchableOpacity>
 				</View>
-			</Drawer>
+			</Header>
 		);
 	}
 }
 
-AccountDisplay.propTypes = {
-	// from redux
-	userLogout: React.PropTypes.func,
-}
-
-const mapStateToProps = (store) => { return {} }
-
-const mapDispatchToProps = (dispatch) => {
-	return {
-		userLogout: () => dispatch(userOperations.userLogout())
-	}
-}
-export default connect(mapStateToProps, mapDispatchToProps)(AccountDisplay);
+export default AccountDisplay;


### PR DESCRIPTION
Instead of having three separated components (`Header`, `SideMenu` and `Drawer`) in each route, use only one single component (`Header`)

Two tables of objects of actions are given to `Header` as props:
-  `quickActions` contains the actions displayed in the `Header` and accessible directly
- `menuActions` contains the actions displayed in the side menu