### PR TITLE
Replace nav bar by header in MainTab routes

### DIFF
--- a/app/App/App.js
+++ b/app/App/App.js
@@ -63,6 +63,7 @@ class App extends Component {
 
 							<Scene
 								component={ProductsListContainer}
+								hideNavBar={true}
 								icon={() => {return (<Text>Produits</Text>)}}
 								key="ProductsList"
 								title="Les produits du plateau"

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -46,6 +46,7 @@ class App extends Component {
 
 							<Scene
 								component={NewsContainer}
+								hideNavBar={true}
 								icon={() => {return (<Text>Actualités</Text>)}}
 								initial={true}
 								key="News"

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -55,9 +55,10 @@ class App extends Component {
 
 							<Scene
 								component={EventsListContainer}
+								hideNavBar={true}
 								icon={() => {return (<Text>Events</Text>)}}
 								key="EventsList"
-								title="Mes abonnements"
+								title="Abonnements"
 								/>
 
 							<Scene

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -71,6 +71,7 @@ class App extends Component {
 
 							<Scene
 								component={FarmsListContainer}
+								hideNavBar={true}
 								icon={() => {return (<Text>Fermes</Text>)}}
 								key="FarmsList"
 								title="Les fermes du plateau"

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -21,7 +21,7 @@ class Header extends Component {
 			<Drawer
 				acceptPan={true}
 				content={<SideMenu actions={this.props.menuActions} />}
-				openDrawerOffset={0.1}
+				openDrawerOffset={0.15}
 				ref={(ref) => this._sideMenu = ref}
 				side="right"
 				tapToClose={true}
@@ -108,7 +108,7 @@ const mapDispatchToProps = (dispatch) => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-	stateProps.menuActions = ownProps.menuActions.concat([
+	stateProps.menuActions = (ownProps.menuActions || []).concat([
 		{
 			// Adds logout option to the SideMenu
 			label: 'Logout',

--- a/app/routes/EventsList/EventsListContainer.js
+++ b/app/routes/EventsList/EventsListContainer.js
@@ -6,6 +6,7 @@ import settings from '../../config/settings';
 import * as eventOperations from '../../operations/eventOperations'
 
 import EventsList from './EventsList';
+import Header from '../../components/Header';
 
 class EventsListContainer extends Component {
 
@@ -24,7 +25,9 @@ class EventsListContainer extends Component {
 			)
 		} else {
 			return (
-				<EventsList	eventsList={this.props.eventsList} />
+				<Header title={this.props.title}>
+					<EventsList	eventsList={this.props.eventsList} />
+				</Header>
 			)
 		}
 	}

--- a/app/routes/EventsList/styles.js
+++ b/app/routes/EventsList/styles.js
@@ -6,11 +6,10 @@ export default styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		paddingBottom: metrics.navBarHeight,
-		paddingTop: metrics.navBarHeight
 	},
 	separator: {
 		flex: 1,
 		height: StyleSheet.hairlineWidth,
 		backgroundColor: colors.greyLight,
-  },
+	},
 });

--- a/app/routes/FarmsList/FarmsListContainer.js
+++ b/app/routes/FarmsList/FarmsListContainer.js
@@ -6,6 +6,7 @@ import settings from '../../config/settings'
 import * as farmOperations from '../../operations/farmOperations'
 
 import FarmsList from './FarmsList'
+import Header from '../../components/Header'
 
 class FarmsListContainer extends Component {
 
@@ -24,7 +25,9 @@ class FarmsListContainer extends Component {
 			)
 		} else {
 			return (
-				<FarmsList	farmsList={this.props.farmsList} />
+				<Header title={this.props.title}>
+					<FarmsList	farmsList={this.props.farmsList} />
+				</Header>
 			)
 		}
 	}

--- a/app/routes/FarmsList/styles.js
+++ b/app/routes/FarmsList/styles.js
@@ -6,7 +6,6 @@ export default styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		paddingBottom: metrics.navBarHeight,
-		paddingTop: metrics.navBarHeight
 	},
 	separator: {
 		backgroundColor: colors.greyLight,

--- a/app/routes/News/NewsContainer.js
+++ b/app/routes/News/NewsContainer.js
@@ -6,7 +6,8 @@ import _ from 'lodash'
 
 import * as newsOperations from '../../operations/newsOperations'
 
-import News from './News.js'
+import Header from '../../components/Header'
+import News from './News'
 
 class NewsContainer extends Component {
 
@@ -33,15 +34,17 @@ class NewsContainer extends Component {
 			)
 		} else {
 			return (
-				<News
-					showEventsList = {this.showEventsList}
-					showFarmsList = {this.showFarmsList}
-					showProductsList = {this.showProductsList}
+				<Header title={this.props.title}>
+					<News
+						showEventsList = {this.showEventsList}
+						showFarmsList = {this.showFarmsList}
+						showProductsList = {this.showProductsList}
 
-					eventsList = {this.props.featuredEvents}
-					farmsList = {this.props.featuredFarms}
-					productsList = {this.props.featuredProducts}
-					/>
+						eventsList = {this.props.featuredEvents}
+						farmsList = {this.props.featuredFarms}
+						productsList = {this.props.featuredProducts}
+						/>
+				</Header>
 			)
 		}
 	}

--- a/app/routes/News/styles.js
+++ b/app/routes/News/styles.js
@@ -5,6 +5,5 @@ export default styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		paddingBottom: metrics.navBarHeight,
-		paddingTop: metrics.navBarHeight
 	},
 });

--- a/app/routes/ProductsList/ProductsListContainer.js
+++ b/app/routes/ProductsList/ProductsListContainer.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import settings from '../../config/settings';
 import * as productOperations from '../../operations/productOperations';
 
+import Header from '../../components/Header';
 import ProductsList from './ProductsList';
 
 class ProductsListContainer extends Component {
@@ -24,7 +25,9 @@ class ProductsListContainer extends Component {
 			)
 		} else {
 			return (
-				<ProductsList	productsList={this.props.productsList} />
+				<Header title={this.props.title}>
+					<ProductsList	productsList={this.props.productsList} />
+				</Header>
 			)
 		}
 	}

--- a/app/routes/ProductsList/styles.js
+++ b/app/routes/ProductsList/styles.js
@@ -6,7 +6,6 @@ const styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		paddingBottom: metrics.navBarHeight,
-		paddingTop: metrics.navBarHeight,
 	},
 	separator: {
 		backgroundColor: colors.greyLight,


### PR DESCRIPTION
## Fix

Quick fix of the `Header` component where the `menuActions` prop was compulsory.

## Concerned routes
- News
- EventsList
- ProductsList
- FarmsList

## Screenshots

![screenshot_1488800352_thumbnail](https://cloud.githubusercontent.com/assets/15690915/23608676/ca12087a-026a-11e7-9a16-7fa3d54e9153.png)

![screenshot_1488800346_thumbnail](https://cloud.githubusercontent.com/assets/15690915/23608672/bd19cc48-026a-11e7-9f1e-2da90183d623.png)
