### PR TITLE
Replace nav bar by header in detail routes

### DIFF
--- a/app/App/App.js
+++ b/app/App/App.js
@@ -89,21 +89,21 @@ class App extends Component {
 
 						<Scene
 							component={EventDetailContainer}
-							hideNavBar={false}
+							hideNavBar={true}
 							key="EventDetailContainer"
 							title="Détails de l'évènement"
 							/>
 
 						<Scene
 							component={FarmDetailContainer}
-							hideNavBar={false}
+							hideNavBar={true}
 							key="FarmDetailContainer"
 							title="Détails de la ferme"
 							/>
 
 						<Scene
 							component={ProductDetailContainer}
-							hideNavBar={false}
+							hideNavBar={true}
 							key="ProductDetailContainer"
 							title="Détails du produit"
 							/>

--- a/app/components/Frame/Frame.js
+++ b/app/components/Frame/Frame.js
@@ -1,0 +1,91 @@
+import React, { Component } from 'react'
+import { Text, View } from 'react-native'
+import Drawer from 'react-native-drawer'
+import { ActionConst, Actions } from 'react-native-router-flux'
+import { connect } from 'react-redux'
+
+import styles from './styles'
+
+import * as userOperations from '../../operations/userOperations'
+
+import Header from '../Header'
+import ImageButton from '../ImageButton'
+import SideMenu from '../SideMenu'
+
+class Frame extends Component {
+	openControlPanel() {
+		this._sideMenu.open()
+	}
+
+	render() {
+		return (
+			<Drawer
+				acceptPan={true}
+				content={<SideMenu actions={this.props.menuActions} />}
+				openDrawerOffset={0.1}
+				ref={(ref) => this._sideMenu = ref}
+				side="right"
+				tapToClose={true}
+				type="overlay"
+				>
+
+				<Header
+					navigation={this.props.navigation}
+					openControlPanel={this.openControlPanel.bind(this)}
+					quickActions={this.props.quickActions}
+					title={this.props.title}
+					/>
+
+				<View style={styles.bodyContainer}>
+					{this.props.children}
+				</View>
+			</Drawer>
+		)
+	}
+}
+
+Frame.propTypes = {
+	// from parent
+	menuActions: React.PropTypes.arrayOf(
+		React.PropTypes.shape({
+			label: React.PropTypes.string.isRequired,
+			onPress: React.PropTypes.func.isRequired,
+	})),
+	navigation: React.PropTypes.shape({
+		onPress: React.PropTypes.func.isRequired,
+		source: React.PropTypes.number.isRequired,
+	}),
+	quickActions: React.PropTypes.arrayOf(
+		React.PropTypes.shape({
+			onPress: React.PropTypes.func.isRequired,
+			source: React.PropTypes.number.isRequired,
+	})),
+	title: React.PropTypes.string.isRequired,
+
+	// from redux
+	userLogout: React.PropTypes.func,
+}
+
+const mapStateToProps = (store) => { return {} }
+
+const mapDispatchToProps = (dispatch) => {
+	return {
+		userLogout: () => dispatch(userOperations.userLogout())
+	}
+}
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+	stateProps.menuActions = (ownProps.menuActions || []).concat([
+		{
+			// Adds logout option to the SideMenu
+			label: 'Logout',
+			onPress: function(){
+				dispatchProps.userLogout()
+				Actions.Authentication({type: ActionConst.RESET})
+			}
+		}
+	])
+	return Object.assign({}, ownProps, stateProps, dispatchProps)
+}
+
+export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Frame);

--- a/app/components/Frame/index.js
+++ b/app/components/Frame/index.js
@@ -1,0 +1,3 @@
+import Frame from './Frame'
+
+export default Frame

--- a/app/components/Frame/styles.js
+++ b/app/components/Frame/styles.js
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+import colors from '../../config/colors';
+import metrics from '../../config/metrics';
+
+export default styles = StyleSheet.create({
+	bodyContainer: {
+		flex: 1,
+	},
+});

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -1,124 +1,70 @@
 import React, { Component } from 'react'
 import { Text, View } from 'react-native'
-import Drawer from 'react-native-drawer'
-import { ActionConst, Actions } from 'react-native-router-flux'
-import { connect } from 'react-redux'
 
 import styles from './styles'
 
-import * as userOperations from '../../operations/userOperations'
-
 import ImageButton from '../ImageButton'
-import SideMenu from '../SideMenu'
 
 class Header extends Component {
-	openControlPanel() {
-		this._sideMenu.open()
-	}
-
 	render() {
 		return (
-			<Drawer
-				acceptPan={true}
-				content={<SideMenu actions={this.props.menuActions} />}
-				openDrawerOffset={0.15}
-				ref={(ref) => this._sideMenu = ref}
-				side="right"
-				tapToClose={true}
-				type="overlay"
-				>
-
-				<View style={styles.headerContainer}>
-					<View style={styles.navContainer}>
-						{
-							this.props.navigation &&
-							<ImageButton
-								onPress={this.props.navigation.onPress}
-								source={this.props.navigation.source}
-								/>
-						}
-					</View>
-
-					<View style={styles.titleContainer}>
-						<Text style={styles.title}>
-							{this.props.title}
-						</Text>
-					</View>
-
-					<View style={styles.quickActionsContainer}>
-						{
-							this.props.quickActions &&
-							this.props.quickActions.length > 0 &&
-							this.props.quickActions.map(function(action, key){
-								return (
-									<ImageButton
-										key={key}
-										onPress={action.onPress}
-										source={action.source}
-										/>
-								)
-							})
-						}
-
-						{
-							<ImageButton
-								onPress={this.openControlPanel.bind(this)}
-								source={require('../../images/menu.png')}
-								/>
-						}
-					</View>
+			<View style={styles.headerContainer}>
+				<View style={styles.navContainer}>
+					{
+						this.props.navigation &&
+						<ImageButton
+							onPress={this.props.navigation.onPress}
+							source={this.props.navigation.source}
+							/>
+					}
 				</View>
 
-				<View style={styles.mainContainer}>
-					{this.props.children}
+				<View style={styles.titleContainer}>
+					<Text style={styles.title}>
+						{this.props.title}
+					</Text>
 				</View>
-			</Drawer>
+
+				<View style={styles.quickActionsContainer}>
+					{
+						this.props.quickActions &&
+						this.props.quickActions.length > 0 &&
+						this.props.quickActions.map(function(action, key){
+							return (
+								<ImageButton
+									key={key}
+									onPress={action.onPress}
+									source={action.source}
+									/>
+							)
+						})
+					}
+
+					{
+						<ImageButton
+							onPress={this.props.openControlPanel}
+							source={require('../../images/menu.png')}
+							/>
+					}
+				</View>
+			</View>
 		)
 	}
 }
 
 Header.propTypes = {
 	// from parent
-	menuActions: React.PropTypes.arrayOf(
-		React.PropTypes.shape({
-			label: React.PropTypes.string.isRequired,
-			onPress: React.PropTypes.func.isRequired,
-	})),
 	navigation: React.PropTypes.shape({
 		onPress: React.PropTypes.func.isRequired,
 		source: React.PropTypes.number.isRequired,
 	}),
+	openControlPanel: React.PropTypes.func.isRequired,
 	quickActions: React.PropTypes.arrayOf(
 		React.PropTypes.shape({
 			onPress: React.PropTypes.func.isRequired,
 			source: React.PropTypes.number.isRequired,
 	})),
 	title: React.PropTypes.string.isRequired,
-
-	// from redux
-	userLogout: React.PropTypes.func,
 }
 
-const mapStateToProps = (store) => { return {} }
-
-const mapDispatchToProps = (dispatch) => {
-	return {
-		userLogout: () => dispatch(userOperations.userLogout())
-	}
-}
-
-const mergeProps = (stateProps, dispatchProps, ownProps) => {
-	stateProps.menuActions = (ownProps.menuActions || []).concat([
-		{
-			// Adds logout option to the SideMenu
-			label: 'Logout',
-			onPress: function(){
-				dispatchProps.userLogout()
-				Actions.Authentication({type: ActionConst.REPLACE})
-			}
-		}
-	])
-	return Object.assign({}, ownProps, stateProps, dispatchProps)
-}
-
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Header);
+export default Header

--- a/app/components/Header/styles.js
+++ b/app/components/Header/styles.js
@@ -13,9 +13,6 @@ export default styles = StyleSheet.create({
 		paddingLeft: metrics.basePadding,
 		paddingRight: metrics.basePadding,
 	},
-	mainContainer: {
-		flex: 1,
-	},
 	navContainer: {
 		flex: 0.25,
 		flexDirection: 'row',

--- a/app/routes/AccountDisplay/AccountDisplay.js
+++ b/app/routes/AccountDisplay/AccountDisplay.js
@@ -6,12 +6,12 @@ import { connect } from 'react-redux';
 import settings from '../../config/settings';
 import styles from './styles';
 
-import Header from '../../components/Header'
+import Frame from '../../components/Frame'
 
 class AccountDisplay extends Component {
 	render() {
 		return (
-			<Header
+			<Frame
 				menuActions={[
 					{
 						label: 'Awesome option',
@@ -99,7 +99,7 @@ class AccountDisplay extends Component {
 						</Text>
 					</TouchableOpacity>
 				</View>
-			</Header>
+			</Frame>
 		);
 	}
 }

--- a/app/routes/EventDetail/EventDetailContainer.js
+++ b/app/routes/EventDetail/EventDetailContainer.js
@@ -1,26 +1,36 @@
 import React, {Component} from 'react';
+import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
-import _ from 'lodash'
+import _ from 'lodash';
 
-import promises from '../../config/promises.js'
-import settings from '../../config/settings.js'
-import * as eventOperations from '../../operations/eventOperations'
+import promises from '../../config/promises';
+import settings from '../../config/settings';
+import * as eventOperations from '../../operations/eventOperations';
 
-import EventDetail from './EventDetail.js';
+import EventDetail from './EventDetail';
+import Frame from '../../components/Frame';
 
 class EventDetailContainer extends Component {
 
 	render() {
 		var {idToken, id, pinned} = this.props
 		return(
-			<EventDetail
-				togglePinStatus={this.props.togglePinStatus.bind(this, idToken, id, pinned)}
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<EventDetail
+					togglePinStatus={this.props.togglePinStatus.bind(this, idToken, id, pinned)}
 
-				description={this.props.description}
-				endAt={this.props.endAt}
-				farmId={this.props.farmId}
-				isPinned={this.props.pinned}
-				/>
+					description={this.props.description}
+					endAt={this.props.endAt}
+					farmId={this.props.farmId}
+					isPinned={this.props.pinned}
+					/>
+			</Frame>
 		)
 	}
 }

--- a/app/routes/EventDetail/styles.js
+++ b/app/routes/EventDetail/styles.js
@@ -13,7 +13,7 @@ export default styles = StyleSheet.create({
 		borderRadius: metrics.borderRadius,
 	},
 	container: {
-		top: metrics.navBarHeight
+		flex: 1,
 	},
 	description: {
 		fontSize: 30,

--- a/app/routes/EventsList/EventsListContainer.js
+++ b/app/routes/EventsList/EventsListContainer.js
@@ -6,7 +6,7 @@ import settings from '../../config/settings';
 import * as eventOperations from '../../operations/eventOperations'
 
 import EventsList from './EventsList';
-import Header from '../../components/Header';
+import Frame from '../../components/Frame';
 
 class EventsListContainer extends Component {
 
@@ -17,13 +17,13 @@ class EventsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Header title={this.props.title}>
+			<Frame title={this.props.title}>
 				<EventsList
 					eventsList={this.props.eventsList}
 					isLoading={this.props.isLoading}
 					onRefresh={this.onRefresh.bind(this)}
 				/>
-			</Header>
+			</Frame>
 		)
 	}
 }

--- a/app/routes/FarmDetail/FarmDetailContainer.js
+++ b/app/routes/FarmDetail/FarmDetailContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
 import _ from 'lodash'
 
@@ -6,26 +7,35 @@ import promises from '../../config/promises.js'
 import settings from '../../config/settings.js'
 import * as farmOperations from '../../operations/farmOperations'
 
-import FarmDetail from './FarmDetail.js';
+import FarmDetail from './FarmDetail';
+import Frame from '../../components/Frame';
 
 class FarmDetailContainer extends Component {
 
 	render() {
 		var {idToken, id, subscribed} = this.props
 		return(
-			<FarmDetail
-				toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<FarmDetail
+					toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
 
-				address={this.props.address}
-				email={this.props.email}
-				id={this.props.id}
-				isSubscribed={this.props.subscribed}
-				name={this.props.name}
-				ownerId={this.props.ownerId}
-				phone={this.props.phone}
-				products={this.props.products}
-				website={this.props.website}
-				/>
+					address={this.props.address}
+					email={this.props.email}
+					id={this.props.id}
+					isSubscribed={this.props.subscribed}
+					name={this.props.name}
+					ownerId={this.props.ownerId}
+					phone={this.props.phone}
+					products={this.props.products}
+					website={this.props.website}
+					/>
+			</Frame>
 		)
 	}
 }

--- a/app/routes/FarmDetail/styles.js
+++ b/app/routes/FarmDetail/styles.js
@@ -38,7 +38,6 @@ const styles = StyleSheet.create({
 	},
 	mainContainer: {
 		flex: 1,
-		top: metrics.navBarHeight,
 	},
 	name: {
 		color: colors.lightGrey,

--- a/app/routes/FarmsList/FarmsListContainer.js
+++ b/app/routes/FarmsList/FarmsListContainer.js
@@ -6,7 +6,7 @@ import settings from '../../config/settings'
 import * as farmOperations from '../../operations/farmOperations'
 
 import FarmsList from './FarmsList'
-import Header from '../../components/Header'
+import Frame from '../../components/Frame'
 
 class FarmsListContainer extends Component {
 
@@ -17,13 +17,13 @@ class FarmsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Header title={this.props.title}>
+			<Frame title={this.props.title}>
 				<FarmsList
 					farmsList={this.props.farmsList}
 					isLoading={this.props.isLoading}
 					onRefresh={this.onRefresh.bind(this)}
 				/>
-			</Header>
+			</Frame>
 		)
 	}
 }

--- a/app/routes/News/NewsContainer.js
+++ b/app/routes/News/NewsContainer.js
@@ -6,7 +6,7 @@ import _ from 'lodash'
 
 import * as newsOperations from '../../operations/newsOperations'
 
-import Header from '../../components/Header'
+import Frame from '../../components/Frame'
 import News from './News'
 
 class NewsContainer extends Component {
@@ -34,7 +34,7 @@ class NewsContainer extends Component {
 			)
 		} else {
 			return (
-				<Header title={this.props.title}>
+				<Frame title={this.props.title}>
 					<News
 						showEventsList = {this.showEventsList}
 						showFarmsList = {this.showFarmsList}
@@ -44,7 +44,7 @@ class NewsContainer extends Component {
 						farmsList = {this.props.featuredFarms}
 						productsList = {this.props.featuredProducts}
 						/>
-				</Header>
+				</Frame>
 			)
 		}
 	}

--- a/app/routes/ProductDetail/ProductDetailContainer.js
+++ b/app/routes/ProductDetail/ProductDetailContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { Actions } from 'react-native-router-flux'
 import { connect } from 'react-redux'
 import _ from 'lodash'
 
@@ -6,6 +7,7 @@ import promises from '../../config/promises'
 import settings from '../../config/settings'
 import * as productOperations from '../../operations/productOperations'
 
+import Frame from '../../components/Frame'
 import ProductDetail from './ProductDetail'
 
 class ProductDetailContainer extends Component {
@@ -13,13 +15,21 @@ class ProductDetailContainer extends Component {
 	render() {
 		var {idToken, id, subscribed} = this.props
 		return(
-			<ProductDetail
-				toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<ProductDetail
+					toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
 
-				farms={this.props.farms}
-				name={this.props.name}
-				isSubscribed={this.props.subscribed}
-				/>
+					farms={this.props.farms}
+					name={this.props.name}
+					isSubscribed={this.props.subscribed}
+					/>
+			</Frame>
 		)
 	}
 }

--- a/app/routes/ProductDetail/styles.js
+++ b/app/routes/ProductDetail/styles.js
@@ -13,7 +13,7 @@ export default styles = StyleSheet.create({
 		borderRadius: metrics.borderRadius,
 	},
 	container: {
-		top: metrics.navBarHeight,
+		flex: 1,
 	},
 	name: {
 		fontSize: 30,

--- a/app/routes/ProductsList/ProductsListContainer.js
+++ b/app/routes/ProductsList/ProductsListContainer.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import settings from '../../config/settings';
 import * as productOperations from '../../operations/productOperations';
 
-import Header from '../../components/Header';
+import Frame from '../../components/Frame';
 import ProductsList from './ProductsList';
 
 class ProductsListContainer extends Component {
@@ -17,13 +17,13 @@ class ProductsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Header title={this.props.title}>
+			<Frame title={this.props.title}>
 				<ProductsList
 					productsList={this.props.productsList}
 					isLoading={this.props.isLoading}
 					onRefresh={this.onRefresh.bind(this)}
 				/>
-			</Header>
+			</Frame>
 		)
 	}
 }


### PR DESCRIPTION
## Fix

- When the logout action was triggered, the top nav stack element was replaced by the `Authentication` route. Now the nav stack is reset.
- Replacement of the `Header` component by the `Frame` component in the `xxxList` routes.

## Refactor of Header component

The `Header` component has been split into two components: `Frame` and `Header`. The `Frame` includes the `Header`, the `SideMenu` and the body part of the page. This is this component which is used by the routes instead of the `Header`.

## Concerned routes

- `News`
- `EventList`
- `ProductList`
- `FarmList`
- `EventDetail`
- `ProductDetail`
- `FarmDetail`

## Screenshots

![screenshot_1488803953_thumbnail](https://cloud.githubusercontent.com/assets/15690915/23610332/5a3620d8-0272-11e7-993e-c6ee1fa6ac13.png)

![screenshot_1488804040_thumbnail](https://cloud.githubusercontent.com/assets/15690915/23610377/87d38d50-0272-11e7-84d6-2fd905bb3314.png)
