### PR TITLE
Refresh lists when pull down

### DIFF
--- a/app/routes/EventsList/EventsList.js
+++ b/app/routes/EventsList/EventsList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ListView, View } from 'react-native';
+import { ListView, RefreshControl, View } from 'react-native';
 
 import styles from './styles';
 
@@ -28,6 +28,12 @@ class EventsList extends Component {
 					dataSource={dataSource}
 					renderRow={this.renderRow}
 					renderSeparator={(sectionId, rowId) => <View key={rowId} style={styles.separator} />}
+					refreshControl={
+						<RefreshControl
+							refreshing={this.props.isLoading}
+							onRefresh={this.props.onRefresh}
+						/>
+					}
 					/>
 			</View>
 		)
@@ -36,7 +42,9 @@ class EventsList extends Component {
 
 EventsList.propTypes = {
 	// from parent
-	eventsList: React.PropTypes.array,
+	eventsList: React.PropTypes.array.isRequired,
+	isLoading: React.PropTypes.bool.isRequired,
+	onRefresh: React.PropTypes.func.isRequired
 }
 
 export default EventsList;

--- a/app/routes/EventsList/EventsListContainer.js
+++ b/app/routes/EventsList/EventsListContainer.js
@@ -10,26 +10,21 @@ import Header from '../../components/Header';
 
 class EventsListContainer extends Component {
 
-	componentWillMount(){
-		// TODO: find better strategy to load know when to load events list
-		if (!this.props.eventsList.length){
-			this.props.fetchEventsList(this.props.idToken)
-		}
+	onRefresh() {
+		this.props.fetchEventsList(this.props.idToken)
 	}
 
 	// TODO: add error handling
 	render() {
-		if (this.props.isLoading) {
-			return (
-				<ActivityIndicator />
-			)
-		} else {
-			return (
-				<Header title={this.props.title}>
-					<EventsList	eventsList={this.props.eventsList} />
-				</Header>
-			)
-		}
+		return (
+			<Header title={this.props.title}>
+				<EventsList
+					eventsList={this.props.eventsList}
+					isLoading={this.props.isLoading}
+					onRefresh={this.onRefresh.bind(this)}
+				/>
+			</Header>
+		)
 	}
 }
 

--- a/app/routes/FarmsList/FarmsList.js
+++ b/app/routes/FarmsList/FarmsList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { ListView, View } from 'react-native'
+import { ListView, RefreshControl, View } from 'react-native'
 
 import styles from './styles'
 
@@ -26,7 +26,13 @@ class FarmsList extends Component {
 					dataSource={dataSource}
 					renderRow={this.renderRow}
 					renderSeparator={(sectionId, rowId) => <View key={rowId} style={styles.separator} />}
-					/>
+					refreshControl={
+						<RefreshControl
+							refreshing={this.props.isLoading}
+							onRefresh={this.props.onRefresh}
+						/>
+					}
+				/>
 			</View>
 		)
 	}
@@ -34,7 +40,9 @@ class FarmsList extends Component {
 
 FarmsList.propTypes = {
 	// from parent
-	farmsList: React.PropTypes.array,
+	farmsList: React.PropTypes.array.isRequired,
+	isLoading: React.PropTypes.bool.isRequired,
+	onRefresh: React.PropTypes.func.isRequired
 }
 
 export default FarmsList;

--- a/app/routes/FarmsList/FarmsListContainer.js
+++ b/app/routes/FarmsList/FarmsListContainer.js
@@ -10,26 +10,21 @@ import Header from '../../components/Header'
 
 class FarmsListContainer extends Component {
 
-	componentWillMount(){
-		// TODO: find better strategy to load know when to load farms list
-		if (!this.props.farmsList.length){
-			this.props.fetchFarmsList(this.props.idToken)
-		}
+	onRefresh() {
+		this.props.fetchFarmsList(this.props.idToken)
 	}
 
 	// TODO: add error handling
 	render() {
-		if (this.props.isLoading) {
-			return (
-				<ActivityIndicator />
-			)
-		} else {
-			return (
-				<Header title={this.props.title}>
-					<FarmsList	farmsList={this.props.farmsList} />
-				</Header>
-			)
-		}
+		return (
+			<Header title={this.props.title}>
+				<FarmsList
+					farmsList={this.props.farmsList}
+					isLoading={this.props.isLoading}
+					onRefresh={this.onRefresh.bind(this)}
+				/>
+			</Header>
+		)
 	}
 }
 

--- a/app/routes/ProductsList/ProductsList.js
+++ b/app/routes/ProductsList/ProductsList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ListView, View } from 'react-native';
+import { ListView, RefreshControl, View } from 'react-native';
 
 import styles from './styles';
 
@@ -25,7 +25,13 @@ class ProductsList extends Component {
 					dataSource={dataSource}
 					renderRow={this.renderRow}
 					renderSeparator={(sectionId, rowId) => <View key={rowId} style={styles.separator} />}
-					/>
+					refreshControl={
+						<RefreshControl
+							refreshing={this.props.isLoading}
+							onRefresh={this.props.onRefresh}
+						/>
+					}
+				/>
 			</View>
 		)
 	}
@@ -33,7 +39,9 @@ class ProductsList extends Component {
 
 ProductsList.propTypes = {
 	// from parent
-	productsList: React.PropTypes.array,
+	isLoading: React.PropTypes.bool.isRequired,
+	onRefresh: React.PropTypes.func.isRequired,
+	productsList: React.PropTypes.array.isRequired
 }
 
 export default ProductsList

--- a/app/routes/ProductsList/ProductsListContainer.js
+++ b/app/routes/ProductsList/ProductsListContainer.js
@@ -10,26 +10,21 @@ import ProductsList from './ProductsList';
 
 class ProductsListContainer extends Component {
 
-	componentWillMount(){
-		// TODO: find better strategy to load know when to load products list
-		if (!this.props.productsList.length){
-			this.props.fetchProductsList(this.props.idToken)
-		}
+	onRefresh() {
+		this.props.fetchProductsList(this.props.idToken)
 	}
 
 	// TODO: add error handling
 	render() {
-		if (this.props.isLoading) {
-			return (
-				<ActivityIndicator />
-			)
-		} else {
-			return (
-				<Header title={this.props.title}>
-					<ProductsList	productsList={this.props.productsList} />
-				</Header>
-			)
-		}
+		return (
+			<Header title={this.props.title}>
+				<ProductsList
+					productsList={this.props.productsList}
+					isLoading={this.props.isLoading}
+					onRefresh={this.onRefresh.bind(this)}
+				/>
+			</Header>
+		)
 	}
 }
 


### PR DESCRIPTION
- Update Events, Farms and Products lists when they are pulled down using redux operations
- erase `componentWillMount` method from the list containers because they were never used. The list are already loaded on the news page.
- remove conditional `ActivityLoader` from render method because they prevented the correct rendering of the list refresh loader 