### PR TITLE
Add abstract layer to news route

### DIFF
--- a/app/App/App.js
+++ b/app/App/App.js
@@ -10,7 +10,7 @@ import EventsListRoute from '../routes/EventsList';
 import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
 import FarmsListRoute from '../routes/FarmsList';
-import ProductDetailContainer from '../routes/ProductDetail';
+import ProductDetailRoute from '../routes/ProductDetail';
 import ProductsListRoute from '../routes/ProductsList';
 
 import Loader from '../components/Loader';
@@ -101,9 +101,9 @@ class App extends Component {
 							/>
 
 						<Scene
-							component={ProductDetailContainer}
+							component={ProductDetailRoute}
 							hideNavBar={true}
-							key="ProductDetailContainer"
+							key="ProductDetailRoute"
 							title="Détails du produit"
 							/>
 					</Scene>

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -8,7 +8,7 @@ import Authentication from '../routes/Authentication';
 import EventDetailRoute from '../routes/EventDetail';
 import EventsListRoute from '../routes/EventsList';
 import NewsRoute from '../routes/News';
-import FarmDetailContainer from '../routes/FarmDetail';
+import FarmDetailRoute from '../routes/FarmDetail';
 import FarmsListRoute from '../routes/FarmsList';
 import ProductDetailRoute from '../routes/ProductDetail';
 import ProductsListRoute from '../routes/ProductsList';
@@ -94,9 +94,9 @@ class App extends Component {
 							/>
 
 						<Scene
-							component={FarmDetailContainer}
+							component={FarmDetailRoute}
 							hideNavBar={true}
-							key="FarmDetailContainer"
+							key="FarmDetailRoute"
 							title="Détails de la ferme"
 							/>
 

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 
 import AccountDisplay from '../routes/AccountDisplay';
 import Authentication from '../routes/Authentication';
-import EventDetailContainer from '../routes/EventDetail';
+import EventDetailRoute from '../routes/EventDetail';
 import EventsListRoute from '../routes/EventsList';
 import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
@@ -87,9 +87,9 @@ class App extends Component {
 						</Scene>
 
 						<Scene
-							component={EventDetailContainer}
+							component={EventDetailRoute}
 							hideNavBar={true}
-							key="EventDetailContainer"
+							key="EventDetailRoute"
 							title="Détails de l'évènement"
 							/>
 

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import AccountDisplay from '../routes/AccountDisplay';
 import Authentication from '../routes/Authentication';
 import EventDetailContainer from '../routes/EventDetail';
-import EventsListContainer from '../routes/EventsList';
+import EventsListRoute from '../routes/EventsList';
 import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
 import FarmsListContainer from '../routes/FarmsList';
@@ -53,7 +53,7 @@ class App extends Component {
 								/>
 
 							<Scene
-								component={EventsListContainer}
+								component={EventsListRoute}
 								hideNavBar={true}
 								icon={() => {return (<Text>Events</Text>)}}
 								key="EventsList"

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -11,7 +11,7 @@ import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
 import FarmsListContainer from '../routes/FarmsList';
 import ProductDetailContainer from '../routes/ProductDetail';
-import ProductsListContainer from '../routes/ProductsList';
+import ProductsListRoute from '../routes/ProductsList';
 
 import Loader from '../components/Loader';
 import settings from '../config/settings';
@@ -61,7 +61,7 @@ class App extends Component {
 								/>
 
 							<Scene
-								component={ProductsListContainer}
+								component={ProductsListRoute}
 								hideNavBar={true}
 								icon={() => {return (<Text>Produits</Text>)}}
 								key="ProductsList"

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -7,7 +7,7 @@ import AccountDisplay from '../routes/AccountDisplay';
 import Authentication from '../routes/Authentication';
 import EventDetailContainer from '../routes/EventDetail';
 import EventsListContainer from '../routes/EventsList';
-import NewsContainer from '../routes/News';
+import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
 import FarmsListContainer from '../routes/FarmsList';
 import ProductDetailContainer from '../routes/ProductDetail';
@@ -44,7 +44,7 @@ class App extends Component {
 							>
 
 							<Scene
-								component={NewsContainer}
+								component={NewsRoute}
 								hideNavBar={true}
 								icon={() => {return (<Text>Actualités</Text>)}}
 								initial={true}

--- a/app/App/App.js
+++ b/app/App/App.js
@@ -9,7 +9,7 @@ import EventDetailContainer from '../routes/EventDetail';
 import EventsListRoute from '../routes/EventsList';
 import NewsRoute from '../routes/News';
 import FarmDetailContainer from '../routes/FarmDetail';
-import FarmsListContainer from '../routes/FarmsList';
+import FarmsListRoute from '../routes/FarmsList';
 import ProductDetailContainer from '../routes/ProductDetail';
 import ProductsListRoute from '../routes/ProductsList';
 
@@ -69,7 +69,7 @@ class App extends Component {
 								/>
 
 							<Scene
-								component={FarmsListContainer}
+								component={FarmsListRoute}
 								hideNavBar={true}
 								icon={() => {return (<Text>Fermes</Text>)}}
 								key="FarmsList"

--- a/app/components/Event/Event.js
+++ b/app/components/Event/Event.js
@@ -12,7 +12,7 @@ class Event extends Component {
 	getEventDetail() {
 		promises.getWithToken(settings.urls.EVENTS_URL + this.props.eventId, this.props.idToken)
 		.then((response) => {
-			Actions.EventDetailContainer(response.data)
+			Actions.EventDetailRoute(response.data)
 		})
 		.catch((error) => {
 			console.error(error.response.data)

--- a/app/components/Farm/Farm.js
+++ b/app/components/Farm/Farm.js
@@ -12,7 +12,7 @@ class Farm extends Component {
 	getFarmDetail() {
 		promises.getWithToken(settings.urls.FARMS_URL + this.props.id, this.props.idToken)
 		.then((response) => {
-			Actions.FarmDetailContainer(response.data)
+			Actions.FarmDetailRoute(response.data)
 		})
 		.catch((error) => {
 			console.error(error.response.data)

--- a/app/components/Frame/styles.js
+++ b/app/components/Frame/styles.js
@@ -1,6 +1,4 @@
 import { StyleSheet } from 'react-native';
-import colors from '../../config/colors';
-import metrics from '../../config/metrics';
 
 export default styles = StyleSheet.create({
 	bodyContainer: {

--- a/app/components/Product/Product.js
+++ b/app/components/Product/Product.js
@@ -12,7 +12,7 @@ class Product extends Component {
 	getProductDetail() {
 		promises.getWithToken(settings.urls.PRODUCTS_URL + this.props.id, this.props.idToken)
 		.then((response) => {
-			Actions.ProductDetailContainer(response.data);
+			Actions.ProductDetailRoute(response.data);
 		})
 		.catch((error) => {
 			console.error(error.response.data)

--- a/app/routes/EventDetail/EventDetailContainer.js
+++ b/app/routes/EventDetail/EventDetailContainer.js
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
@@ -8,29 +7,20 @@ import settings from '../../config/settings';
 import * as eventOperations from '../../operations/eventOperations';
 
 import EventDetail from './EventDetail';
-import Frame from '../../components/Frame';
 
 class EventDetailContainer extends Component {
 
 	render() {
 		var {idToken, id, pinned} = this.props
 		return(
-			<Frame
-				navigation={{
-					source: require('../../images/back.png'),
-					onPress: function(){Actions.pop()}
-				}}
-				title={this.props.title}
-				>
-				<EventDetail
-					togglePinStatus={this.props.togglePinStatus.bind(this, idToken, id, pinned)}
+			<EventDetail
+				togglePinStatus={this.props.togglePinStatus.bind(this, idToken, id, pinned)}
 
-					description={this.props.description}
-					endAt={this.props.endAt}
-					farmId={this.props.farmId}
-					isPinned={this.props.pinned}
-					/>
-			</Frame>
+				description={this.props.description}
+				endAt={this.props.endAt}
+				farmId={this.props.farmId}
+				isPinned={this.props.pinned}
+				/>
 		)
 	}
 }
@@ -43,7 +33,6 @@ EventDetailContainer.propTypes = {
 	farmId: React.PropTypes.number,
 	id: React.PropTypes.number,
 	publishAt: React.PropTypes.string,
-	title: React.PropTypes.string,
 
 	// from redux
 	idToken: React.PropTypes.string,

--- a/app/routes/EventDetail/EventDetailRoute.js
+++ b/app/routes/EventDetail/EventDetailRoute.js
@@ -1,0 +1,43 @@
+import React, {Component} from 'react';
+import { Actions } from 'react-native-router-flux';
+
+import settings from '../../config/settings';
+
+import EventDetailContainer from './EventDetailContainer';
+import Frame from '../../components/Frame';
+
+class EventDetailRoute extends Component {
+	render() {
+		return(
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<EventDetailContainer
+					beginAt={this.props.beginAt}
+					description={this.props.description}
+					endAt={this.props.endAt}
+					farmId={this.props.farmId}
+					id={this.props.id}
+					publishAt={this.props.publishAt}
+					/>
+			</Frame>
+		)
+	}
+}
+
+EventDetailRoute.propTypes = {
+	// from parent
+	beginAt: React.PropTypes.string,
+	description: React.PropTypes.string,
+	endAt: React.PropTypes.string,
+	farmId: React.PropTypes.number,
+	id: React.PropTypes.number,
+	publishAt: React.PropTypes.string,
+	title: React.PropTypes.string,
+}
+
+export default EventDetailRoute;

--- a/app/routes/EventDetail/index.js
+++ b/app/routes/EventDetail/index.js
@@ -1,3 +1,3 @@
-import EventDetailContainer from './EventDetailContainer';
+import EventDetailRoute from './EventDetailRoute';
 
-export default EventDetailContainer;
+export default EventDetailRoute;

--- a/app/routes/EventsList/EventsListContainer.js
+++ b/app/routes/EventsList/EventsListContainer.js
@@ -5,7 +5,6 @@ import settings from '../../config/settings';
 import * as eventOperations from '../../operations/eventOperations'
 
 import EventsList from './EventsList';
-import Frame from '../../components/Frame';
 
 class EventsListContainer extends Component {
 
@@ -16,13 +15,11 @@ class EventsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Frame title={this.props.title}>
-				<EventsList
-					eventsList={this.props.eventsList}
-					isLoading={this.props.isLoading}
-					onRefresh={this.onRefresh.bind(this)}
-				/>
-			</Frame>
+			<EventsList
+				eventsList={this.props.eventsList}
+				isLoading={this.props.isLoading}
+				onRefresh={this.onRefresh.bind(this)}
+			/>
 		)
 	}
 }

--- a/app/routes/EventsList/EventsListRoute.js
+++ b/app/routes/EventsList/EventsListRoute.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+
+import settings from '../../config/settings';
+
+import EventsListContainer from './EventsListContainer';
+import Frame from '../../components/Frame';
+
+class EventsListRoute extends Component {
+	render() {
+		return (
+			<Frame title={this.props.title}>
+				<EventsListContainer/>
+			</Frame>
+		)
+	}
+}
+
+export default EventsListRoute;

--- a/app/routes/EventsList/index.js
+++ b/app/routes/EventsList/index.js
@@ -1,3 +1,3 @@
-import EventsListContainer from './EventsListContainer';
+import EventsListRoute from './EventsListRoute';
 
-export default EventsListContainer;
+export default EventsListRoute;

--- a/app/routes/FarmDetail/FarmDetail.js
+++ b/app/routes/FarmDetail/FarmDetail.js
@@ -5,7 +5,7 @@ import ScrollableTabView, {DefaultTabBar} from 'react-native-scrollable-tab-view
 import styles from './styles';
 
 // TODO: get the events related to this farm once the root is updated
-import EventsListContainer from '../EventsList';
+import EventsListContainer from '../EventsList/EventsListContainer.js';
 import ProductsList from '../ProductsList/ProductsList.js'
 
 const FarmDetail = (props) => {
@@ -73,10 +73,16 @@ const FarmDetail = (props) => {
 				<View>
 					<ScrollableTabView renderTabBar={() => <DefaultTabBar />} >
 						<View tabLabel='Évènements'>
+							{ /* TODO: load only events published by the farm */ }
 							<EventsListContainer />
 						</View>
 						<ScrollView tabLabel='Produits'>
-							<ProductsList productsList={props.products} />
+							{ /* TODO: load only products published by the farm */ }
+							<ProductsList
+								isLoading={false}
+								onRefresh={()=>{}}
+								productsList={props.products}
+								/>
 						</ScrollView>
 					</ScrollableTabView>
 				</View>

--- a/app/routes/FarmDetail/FarmDetailContainer.js
+++ b/app/routes/FarmDetail/FarmDetailContainer.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
 import _ from 'lodash'
 
@@ -8,34 +7,25 @@ import settings from '../../config/settings.js'
 import * as farmOperations from '../../operations/farmOperations'
 
 import FarmDetail from './FarmDetail';
-import Frame from '../../components/Frame';
 
 class FarmDetailContainer extends Component {
 
 	render() {
 		var {idToken, id, subscribed} = this.props
 		return(
-			<Frame
-				navigation={{
-					source: require('../../images/back.png'),
-					onPress: function(){Actions.pop()}
-				}}
-				title={this.props.title}
-				>
-				<FarmDetail
-					toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
+			<FarmDetail
+				toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
 
-					address={this.props.address}
-					email={this.props.email}
-					id={this.props.id}
-					isSubscribed={this.props.subscribed}
-					name={this.props.name}
-					ownerId={this.props.ownerId}
-					phone={this.props.phone}
-					products={this.props.products}
-					website={this.props.website}
-					/>
-			</Frame>
+				address={this.props.address}
+				email={this.props.email}
+				id={this.props.id}
+				isSubscribed={this.props.subscribed}
+				name={this.props.name}
+				ownerId={this.props.ownerId}
+				phone={this.props.phone}
+				products={this.props.products}
+				website={this.props.website}
+				/>
 		)
 	}
 }
@@ -48,6 +38,11 @@ FarmDetailContainer.propTypes = {
 	name: React.PropTypes.string,
 	ownerId: React.PropTypes.number,
 	phone: React.PropTypes.string,
+	products: React.PropTypes.arrayOf(
+		React.PropTypes.shape({
+			id: React.PropTypes.number.isRequired,
+			name: React.PropTypes.string.isRequired,
+	})),
 	website: React.PropTypes.string,
 
 	// from redux

--- a/app/routes/FarmDetail/FarmDetailRoute.js
+++ b/app/routes/FarmDetail/FarmDetailRoute.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react'
+import { Actions } from 'react-native-router-flux';
+
+import settings from '../../config/settings.js'
+
+import FarmDetailContainer from './FarmDetailContainer';
+import Frame from '../../components/Frame';
+
+class FarmDetailRoute extends Component {
+	render() {
+		return(
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<FarmDetailContainer
+					address={this.props.address}
+					email={this.props.email}
+					id={this.props.id}
+					name={this.props.name}
+					ownerId={this.props.ownerId}
+					phone={this.props.phone}
+					products={this.props.products}
+					website={this.props.website}
+					/>
+			</Frame>
+		)
+	}
+}
+
+FarmDetailRoute.propTypes = {
+	// from parent
+	address: React.PropTypes.string,
+	email: React.PropTypes.string,
+	id: React.PropTypes.number,
+	name: React.PropTypes.string,
+	ownerId: React.PropTypes.number,
+	phone: React.PropTypes.string,
+	products: React.PropTypes.arrayOf(
+		React.PropTypes.shape({
+			id: React.PropTypes.number.isRequired,
+			name: React.PropTypes.string.isRequired,
+	})),
+	website: React.PropTypes.string,
+}
+
+export default FarmDetailRoute

--- a/app/routes/FarmDetail/index.js
+++ b/app/routes/FarmDetail/index.js
@@ -1,3 +1,3 @@
-import FarmDetailContainer from './FarmDetailContainer'
+import FarmDetailRoute from './FarmDetailRoute'
 
-export default FarmDetailContainer
+export default FarmDetailRoute

--- a/app/routes/FarmsList/FarmsListContainer.js
+++ b/app/routes/FarmsList/FarmsListContainer.js
@@ -5,7 +5,6 @@ import settings from '../../config/settings'
 import * as farmOperations from '../../operations/farmOperations'
 
 import FarmsList from './FarmsList'
-import Frame from '../../components/Frame'
 
 class FarmsListContainer extends Component {
 
@@ -16,13 +15,11 @@ class FarmsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Frame title={this.props.title}>
-				<FarmsList
-					farmsList={this.props.farmsList}
-					isLoading={this.props.isLoading}
-					onRefresh={this.onRefresh.bind(this)}
-				/>
-			</Frame>
+			<FarmsList
+				farmsList={this.props.farmsList}
+				isLoading={this.props.isLoading}
+				onRefresh={this.onRefresh.bind(this)}
+			/>
 		)
 	}
 }

--- a/app/routes/FarmsList/FarmsListRoute.js
+++ b/app/routes/FarmsList/FarmsListRoute.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react'
+
+import settings from '../../config/settings'
+
+import FarmsListContainer from './FarmsListContainer'
+import Frame from '../../components/Frame'
+
+class FarmsListRoute extends Component {
+	render() {
+		return (
+			<Frame title={this.props.title}>
+				<FarmsListContainer/>
+			</Frame>
+		)
+	}
+}
+
+export default FarmsListRoute;

--- a/app/routes/FarmsList/index.js
+++ b/app/routes/FarmsList/index.js
@@ -1,3 +1,3 @@
-import FarmsListContainer from './FarmsListContainer'
+import FarmsListRoute from './FarmsListRoute'
 
-export default FarmsListContainer
+export default FarmsListRoute

--- a/app/routes/News/NewsContainer.js
+++ b/app/routes/News/NewsContainer.js
@@ -5,8 +5,8 @@ import _ from 'lodash'
 
 import * as newsOperations from '../../operations/newsOperations'
 
-import Frame from '../../components/Frame'
 import Loader from '../../components/Loader'
+
 import News from './News'
 
 class NewsContainer extends Component {
@@ -34,17 +34,15 @@ class NewsContainer extends Component {
 			)
 		} else {
 			return (
-				<Frame title={this.props.title}>
-					<News
-						showEventsList = {this.showEventsList}
-						showFarmsList = {this.showFarmsList}
-						showProductsList = {this.showProductsList}
+				<News
+					showEventsList = {this.showEventsList}
+					showFarmsList = {this.showFarmsList}
+					showProductsList = {this.showProductsList}
 
-						eventsList = {this.props.featuredEvents}
-						farmsList = {this.props.featuredFarms}
-						productsList = {this.props.featuredProducts}
-						/>
-				</Frame>
+					eventsList = {this.props.featuredEvents}
+					farmsList = {this.props.featuredFarms}
+					productsList = {this.props.featuredProducts}
+					/>
 			)
 		}
 	}

--- a/app/routes/News/NewsRoute.js
+++ b/app/routes/News/NewsRoute.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react'
+import { ActivityIndicator } from 'react-native'
+
+import Frame from '../../components/Frame'
+import NewsContainer from './NewsContainer'
+
+class NewsRoute extends Component {
+	render() {
+		return (
+			<Frame title={this.props.title}>
+				<NewsContainer/>
+			</Frame>
+		)
+	}
+}
+
+export default NewsRoute

--- a/app/routes/News/index.js
+++ b/app/routes/News/index.js
@@ -1,3 +1,3 @@
-import NewsContainer from './NewsContainer';
+import NewsRoute from './NewsRoute';
 
-export default NewsContainer;
+export default NewsRoute;

--- a/app/routes/ProductDetail/ProductDetailContainer.js
+++ b/app/routes/ProductDetail/ProductDetailContainer.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { Actions } from 'react-native-router-flux'
 import { connect } from 'react-redux'
 import _ from 'lodash'
 
@@ -7,7 +6,6 @@ import promises from '../../config/promises'
 import settings from '../../config/settings'
 import * as productOperations from '../../operations/productOperations'
 
-import Frame from '../../components/Frame'
 import ProductDetail from './ProductDetail'
 
 class ProductDetailContainer extends Component {
@@ -15,21 +13,13 @@ class ProductDetailContainer extends Component {
 	render() {
 		var {idToken, id, subscribed} = this.props
 		return(
-			<Frame
-				navigation={{
-					source: require('../../images/back.png'),
-					onPress: function(){Actions.pop()}
-				}}
-				title={this.props.title}
-				>
-				<ProductDetail
-					toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
+			<ProductDetail
+				toggleSubscriptionStatus={this.props.toggleSubscriptionStatus.bind(this, idToken, id, subscribed)}
 
-					farms={this.props.farms}
-					name={this.props.name}
-					isSubscribed={this.props.subscribed}
-					/>
-			</Frame>
+				farms={this.props.farms}
+				name={this.props.name}
+				isSubscribed={this.props.subscribed}
+				/>
 		)
 	}
 }

--- a/app/routes/ProductDetail/ProductDetailRoute.js
+++ b/app/routes/ProductDetail/ProductDetailRoute.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react'
+import { Actions } from 'react-native-router-flux'
+
+import settings from '../../config/settings'
+
+import Frame from '../../components/Frame'
+import ProductDetailContainer from './ProductDetailContainer'
+
+class ProductDetailRoute extends Component {
+	render() {
+		return(
+			<Frame
+				navigation={{
+					source: require('../../images/back.png'),
+					onPress: function(){Actions.pop()}
+				}}
+				title={this.props.title}
+				>
+				<ProductDetailContainer
+					farm={this.props.farm}
+					id={this.props.id}
+					name={this.props.name}
+					/>
+			</Frame>
+		)
+	}
+}
+
+ProductDetailRoute.propTypes = {
+	// from parent
+	farms: React.PropTypes.array,
+	id: React.PropTypes.number.isRequired,
+	name: React.PropTypes.string.isRequired,
+}
+
+export default ProductDetailRoute

--- a/app/routes/ProductDetail/index.js
+++ b/app/routes/ProductDetail/index.js
@@ -1,3 +1,3 @@
-import ProductDetailContainer from './ProductDetailContainer'
+import ProductDetailRoute from './ProductDetailRoute'
 
-export default ProductDetailContainer
+export default ProductDetailRoute

--- a/app/routes/ProductsList/ProductsListContainer.js
+++ b/app/routes/ProductsList/ProductsListContainer.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import settings from '../../config/settings';
 import * as productOperations from '../../operations/productOperations';
 
-import Frame from '../../components/Frame';
 import ProductsList from './ProductsList';
 
 class ProductsListContainer extends Component {
@@ -16,13 +15,11 @@ class ProductsListContainer extends Component {
 	// TODO: add error handling
 	render() {
 		return (
-			<Frame title={this.props.title}>
-				<ProductsList
-					productsList={this.props.productsList}
-					isLoading={this.props.isLoading}
-					onRefresh={this.onRefresh.bind(this)}
-				/>
-			</Frame>
+			<ProductsList
+				productsList={this.props.productsList}
+				isLoading={this.props.isLoading}
+				onRefresh={this.onRefresh.bind(this)}
+			/>
 		)
 	}
 }

--- a/app/routes/ProductsList/ProductsListRoute.js
+++ b/app/routes/ProductsList/ProductsListRoute.js
@@ -1,0 +1,18 @@
+import React, { Component } from 'react';
+
+import settings from '../../config/settings';
+
+import Frame from '../../components/Frame';
+import ProductsListContainer from './ProductsListContainer';
+
+class ProductsListRoute extends Component {
+	render() {
+		return (
+			<Frame title={this.props.title}>
+				<ProductsListContainer/>
+			</Frame>
+		)
+	}
+}
+
+export default ProductsListContainer;

--- a/app/routes/ProductsList/index.js
+++ b/app/routes/ProductsList/index.js
@@ -1,3 +1,3 @@
-import ProductsListContainer from './ProductsListContainer'
+import ProductsListRoute from './ProductsListRoute'
 
-export default ProductsListContainer
+export default ProductsListRoute


### PR DESCRIPTION
## Fix

Warnings where raised when the `FarmDetail` was displayed because the `ProductList` component used needed two props `isLoading` and `onRefresh` that were not specified. A quick dirty fix has been applied by defining them with default values before properly solving the problem in the next PR.

## Purpose

Add a new layer between the router and the `NewsContainer` component to add the `Frame` component at a higher level:
```
<Router>
    <NewsRoute>
        <Frame>
            <NewsContainer>
                ...
            </NewsContainer>
        </Frame>
    </NewsRoute>
</Router>
```
instead of
```
<Router>
    <NewsContainer>
        <Frame>
            ...
        </Frame>
    </NewsContainer>
</Router>
```